### PR TITLE
[ci] npm release job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,6 +2,10 @@ name: CI
 
 on:
   - pull_request
+  - push:
+      branches: [ master ]
+      tags:
+        - 'v*'
 
 jobs:
   build:
@@ -58,3 +62,20 @@ jobs:
           export NODE_OPTIONS='--experimental-vm-modules'
 
           pnpm -F '@repris/jest-demo' bench:production
+
+  # Deploy to npm on git refs that begin with 'v'
+  release:
+    runs-on: ubuntu-latest
+    name: Release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: publish
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cat >.npmrc << 'EOF'
+          //registry.npmjs.org/:_authToken=${NPM_TOKEN}
+          EOF
+
+          pnpm publish -r --access public

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,11 +1,7 @@
 name: CI
 
 on:
-  - pull_request
-  - push:
-      branches: [ master ]
-      tags:
-        - 'v*'
+  push
 
 jobs:
   build:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -67,8 +67,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: publish
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cat >.npmrc << 'EOF'
           //registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -70,8 +70,21 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          # NPM token config
           cat >.npmrc << 'EOF'
           //registry.npmjs.org/:_authToken=${NPM_TOKEN}
+          EOF
+
+          # Package Readme
+          cat >packages/jest/README.md << 'EOF'
+          <p align="center">
+            <a href="https://github.com/repris-dev/repris#readme">
+            <img src="https://repris.dev/logo.svg" width="200">
+            </a>
+          </p>
+          <p align="center">
+            <i>Reproducible benchmarking for <a href="jestjs.io">Jest</a></i>
+          </p>
           EOF
 
           pnpm publish -r --access public

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -75,16 +75,4 @@ jobs:
           //registry.npmjs.org/:_authToken=${NPM_TOKEN}
           EOF
 
-          # Package Readme
-          cat >packages/jest/README.md << 'EOF'
-          <p align="center">
-            <a href="https://github.com/repris-dev/repris#readme">
-            <img src="https://repris.dev/logo.svg" width="200">
-            </a>
-          </p>
-          <p align="center">
-            <i>Reproducible benchmarking for <a href="jestjs.io">Jest</a></i>
-          </p>
-          EOF
-
           pnpm publish -r --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 0.8.1
+
+- `@repris/jest` package readme
+
+## 0.8.0
+
+Initial release

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@repris/monorepo",
   "author": "repris",
-  "version": "0.1.0",
   "private": true,
   "engines": {
     "node": "^18"

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repris/base",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "author": {
     "name": "Ray Glover",
     "email": "ray@repris.dev"

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repris/jest",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "author": {
     "name": "Ray Glover",
     "email": "ray@repris.dev"

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -87,7 +87,8 @@
     "build:tsc": "tsc --build tsconfig.json tsconfig.spec.json",
     "build:vite": "MODE=production vite build",
     "build": "run-s -l build:tsc build:vite",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "prepublishOnly": "./script/prepublish.sh"
   },
   "license": "Apache-2.0"
 }

--- a/packages/jest/script/prepublish.sh
+++ b/packages/jest/script/prepublish.sh
@@ -1,0 +1,11 @@
+# Package README (appears on the registry package homepage)
+cat >./README.md << 'EOF'
+<p align="center">
+  <a href="https://github.com/repris-dev/repris#readme">
+    <img src="https://repris.dev/logo.svg" width="200">
+  </a>
+</p>
+<p align="center">
+  <i>Reproducible benchmarking for <a href="jestjs.io">Jest</a></i>
+</p>
+EOF

--- a/packages/samplers/package.json
+++ b/packages/samplers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repris/samplers",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "author": {
     "name": "Ray Glover",
     "email": "ray@repris.dev"


### PR DESCRIPTION
- `pnpm publish` on git tags.
- prepublish script to create a package readme
- bump to v0.8.1