### PR TITLE
[Fix] NaNs in confidence intervals of samples with zero stderr.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.1
+
+- [Fix] `repris compare` NaNs in confidence intervals of samples with zero stderr. (#9)
+
 ## 0.9.0
 
 - `repris compare` Use minimum detectable effect-sizes during testing (#8)

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repris/base",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": {
     "name": "Ray Glover",
     "email": "ray@repris.dev"

--- a/packages/base/src/stats/bootstrap.spec.ts
+++ b/packages/base/src/stats/bootstrap.spec.ts
@@ -214,6 +214,30 @@ describe('studentizedResampler', () => {
     }
   });
 
+  test('Confidence intervals of a sample of zero std-err', () => {
+    const rng = rand.PRNGi32(95);
+    const sample0 = new Float32Array(100).fill(8);
+    const sample1 = new Float32Array(100).fill(5.5);
+
+    const {
+      interval: [lo, hi],
+      power,
+    } = boot.studentizedDifferenceTest(
+      sample0,
+      sample1,
+      (x0, x1) => median(x0) - median(x1),
+      0.99,
+      100,
+      10,
+      rng,
+      true,
+    );
+
+    expect(lo).toEqual(8 - 5.5);
+    expect(hi).toEqual(8 - 5.5);
+    expect(power).toEqual(1);
+  });
+
   /**
    * @see: https://www.samlau.me/test-textbook/ch/18/hyp_studentized.html
    * Skipped because this test takes ~30 seconds to run, but is kept here

--- a/packages/base/src/stats/bootstrap.ts
+++ b/packages/base/src/stats/bootstrap.ts
@@ -222,7 +222,7 @@ export function studentizedDifferenceTest(
   const alpha = 1 - confidence;
   const resampler = pairedStudentizedResampler(x0, x1, estimator, KK, entropy);
 
-  const stat0 = estimator(x0, x1),
+  const stat = estimator(x0, x1),
     pivotalQuantities = new Float64Array(K),
     estStat = new online.Gaussian();
 
@@ -238,7 +238,7 @@ export function studentizedDifferenceTest(
     const hi = ti.estimate + ti.stdErr * pz;
 
     if (hi < 0 || lo > 0) power++;
-    if (ti.estimate < stat0) bias++;
+    if (ti.estimate < stat) bias++;
 
     pivotalQuantities[i] = ti.pivotalQuantity;
     estStat.push(ti.estimate);
@@ -249,8 +249,8 @@ export function studentizedDifferenceTest(
   const p = bc ? biasCorrectedInterval(bias / K, alpha) : [alpha / 2, 1 - alpha / 2];
 
   const interval: [number, number] = [
-    stat0 - estStat.std() * quantile(pivotalQuantities, p[1]),
-    stat0 - estStat.std() * quantile(pivotalQuantities, p[0]),
+    stat - estStat.std() * quantile(pivotalQuantities, p[1]),
+    stat - estStat.std() * quantile(pivotalQuantities, p[0]),
   ];
 
   return {

--- a/packages/base/src/stats/bootstrap.ts
+++ b/packages/base/src/stats/bootstrap.ts
@@ -124,7 +124,7 @@ export function pairedStudentizedResampler(
 
     const esti = estimator(replicate0, replicate1);
     const stdErr = innerBootStat.std();
-    const pivotalQuantity = (esti - est) / stdErr;
+    const pivotalQuantity = stdErr > 0 ? (esti - est) / stdErr : 0;
 
     return {
       replicate: replicate0,

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repris/jest",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": {
     "name": "Ray Glover",
     "email": "ray@repris.dev"

--- a/packages/samplers/package.json
+++ b/packages/samplers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repris/samplers",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": {
     "name": "Ray Glover",
     "email": "ray@repris.dev"


### PR DESCRIPTION
Fixes the appearance of NaN comparisons of samples with 0 stderr. e.g.:
```
./index.test.js
                                                              Index    Change (99% CI)  Baseline
  bleh                                                      50.17µs     -1% (NaN, NaN)   50.67µs
```